### PR TITLE
removed selected channel state and instead push to first channel

### DIFF
--- a/frontend/src/components/UserPage.jsx
+++ b/frontend/src/components/UserPage.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-plusplus */
 import { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { Switch, Route } from 'react-router-dom';
+import { Switch, Route, useHistory } from 'react-router-dom';
 import axios from 'axios';
 
 import Header from './user-components/Header';
@@ -10,9 +10,9 @@ import Chat from './user-components/Chat';
 import AllUsers from './user-components/AllUsers';
 
 function UserPage() {
+  const history = useHistory();
   const [channels, setChannels] = useState([]);
   const [dms, setDms] = useState([]);
-  const [selectedChannel, setSelectedChannel] = useState(null);
 
   const getChannels = async () => {
     const token = localStorage.getItem('token');
@@ -31,7 +31,7 @@ function UserPage() {
 
       if (data) {
         setChannels(data);
-        setSelectedChannel(data[0]);
+        history.push(`/user/${data[0].conversation_id}`);
       }
     } catch (error) {
       console.log(error);
@@ -62,9 +62,6 @@ function UserPage() {
 
   useEffect(() => {
     getChannels();
-  }, []);
-
-  useEffect(() => {
     getDms();
   }, []);
 
@@ -75,13 +72,12 @@ function UserPage() {
         <Sidebar
           channels={channels}
           dms={dms}
-          // setDms={setDms}
+          setDms={setDms}
           setChannels={setChannels}
-          setSelectedChannel={setSelectedChannel}
         />
         <Switch>
           <Route path="/user/:conversationId">
-            <Chat getChannels={getChannels} channels={channels} />
+            <Chat />
           </Route>
           <Route path="/people">
             <AllUsers />

--- a/frontend/src/components/user-components/AddChannelModal.jsx
+++ b/frontend/src/components/user-components/AddChannelModal.jsx
@@ -6,12 +6,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-export const Modal = ({
-  setShowModal,
-  channels,
-  setChannels,
-  setSelectedChannel,
-}) => {
+export const Modal = ({ setShowModal, channels, setChannels }) => {
   // close the modal when clicking outside the modal.
   const history = useHistory();
   const [name, setName] = useState('');
@@ -59,10 +54,7 @@ export const Modal = ({
       const addUserResponse = await addCurrentUserToNewChannelRequest;
 
       if (createChannelResponse && addUserResponse) {
-        // console.log(createChannelResponse.data);
-        // console.log(addUserResponse.data);
         setChannels([...channels, createChannelResponse.data[0]]);
-        setSelectedChannel(createChannelResponse.data[0]);
         setShowModal(false);
         history.push('/user');
         history.push(`user/${conversationId}`);
@@ -122,7 +114,6 @@ Modal.propTypes = {
   setShowModal: PropTypes.func.isRequired,
   channels: PropTypes.array,
   setChannels: PropTypes.func.isRequired,
-  setSelectedChannel: PropTypes.func.isRequired,
 };
 
 const InnerContainer = styled.div`

--- a/frontend/src/components/user-components/Sidebar.jsx
+++ b/frontend/src/components/user-components/Sidebar.jsx
@@ -8,13 +8,7 @@ import Chat from '@material-ui/icons/Chat';
 import Send from '@material-ui/icons/Send';
 import { Modal } from './AddChannelModal';
 
-const Sidebar = ({
-  dms,
-  setDms,
-  channels,
-  setChannels,
-  setSelectedChannel,
-}) => {
+const Sidebar = ({ dms, setDms, channels, setChannels }) => {
   const [showModal, setShowModal] = useState(false);
   const history = useHistory();
 
@@ -28,9 +22,8 @@ const Sidebar = ({
     setShowModal(true);
   };
 
-  const handleChannelClick = (channel) => {
-    setSelectedChannel(channel);
-    goToChannel(channel.conversation_id);
+  const handleChannelClick = (conversation) => {
+    goToChannel(conversation.conversation_id);
   };
 
   return (
@@ -62,7 +55,6 @@ const Sidebar = ({
             setShowModal={setShowModal}
             setChannels={setChannels}
             channels={channels}
-            setSelectedChannel={setSelectedChannel}
           />
         ) : null}
         <ChannelsList>
@@ -106,7 +98,6 @@ Sidebar.propTypes = {
   setChannels: PropTypes.func.isRequired,
   dms: PropTypes.array.isRequired,
   setDms: PropTypes.func,
-  setSelectedChannel: PropTypes.func.isRequired,
 };
 
 export default Sidebar;


### PR DESCRIPTION
1) we don't actually use selectedChannel/setSelectedChannel anymore - so I removed everywhere we pass it around as props
2) to set up the "default channel" functionality - UserPage will push to /users/:conversationId (inside of the getChannels function). If there are no channels it'll just load the sidebar and no chat.
3) removed a lot of console logs